### PR TITLE
파일이 업로드 되지 않았을 때도 제출되는 문제 수정

### DIFF
--- a/src/problem/ProblemContainer.jsx
+++ b/src/problem/ProblemContainer.jsx
@@ -54,6 +54,8 @@ export default function ProblemContainer({ problemId }) {
   }
 
   async function handleSubmitClick() {
+    if (!uploadFile.name) return;
+
     const formData = new FormData();
     formData.append('problemId', problemId);
     formData.append('uploadFile', uploadFile);

--- a/src/problem/ProblemContainer.test.jsx
+++ b/src/problem/ProblemContainer.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import context from 'jest-plugin-context';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -42,11 +43,11 @@ describe('ProblemContainer', () => {
     expect(queryByText(/DOWNLOAD/)).not.toBeNull();
   });
 
-  it('파일을 업로드 및 제출할 수 있습니다.', () => {
+  it('파일을 업로드 할 수 있습니다.', () => {
     const problemId = 1;
     const newFile = new File(['new file'], 'dataset.csv', { type: 'text/csv' });
 
-    const { queryByLabelText, queryByText } = render((<ProblemContainer problemId={problemId} />));
+    const { queryByLabelText } = render((<ProblemContainer problemId={problemId} />));
 
     fireEvent.change(queryByLabelText('파일 선택:'), {
       target: {
@@ -54,12 +55,39 @@ describe('ProblemContainer', () => {
       },
     });
 
-    expect(dispatch).toBeCalled();
+    expect(dispatch).toBeCalledTimes(2);
+  });
 
-    expect(queryByText('제출하기')).not.toBeNull();
+  context('업로드 된 파일이 없을 시', () => {
+    it('파일이 제출되지 않습니다.', () => {
+      const problemId = 1;
 
-    fireEvent.click(queryByText('제출하기'));
+      const { queryByText } = render((<ProblemContainer problemId={problemId} />));
 
-    expect(dispatch).toBeCalled();
+      fireEvent.click(queryByText('제출하기'));
+
+      expect(dispatch).toBeCalledTimes(1);
+    });
+  });
+
+  context('업로드 된 파일이 있을 시', () => {
+    it('파일이 제출됩니다.', () => {
+      const problemId = 1;
+      const newFile = new File(['new file'], 'dataset.csv', { type: 'text/csv' });
+
+      const { queryByLabelText, queryByText } = render((
+        <ProblemContainer problemId={problemId} />
+      ));
+
+      fireEvent.change(queryByLabelText('파일 선택:'), {
+        target: {
+          files: [newFile],
+        },
+      });
+
+      fireEvent.click(queryByText('제출하기'));
+
+      expect(dispatch).toBeCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
문제 페이지에서, 파일을 업로드 하지 않았음에도 제출하기 버튼을 클릭하면 서버에 파일이 제출되는 오류가 있었습니다.
그래서, 파일을 업로드 한 파일이 있을 때만 서버에 파일이 전송되도록 코드를 수정하였습니다.